### PR TITLE
Fixed fallthrough error in PlaidSwiftClient

### DIFF
--- a/PlaidClient/PlaidSwiftClient.swift
+++ b/PlaidClient/PlaidSwiftClient.swift
@@ -205,6 +205,7 @@ public struct PlaidClient {
             if let transactions = data["transactions"] as? [JSON], accounts = data["accounts"] as? [[String : AnyObject]], accountData = accounts.first {
                 let plaidTransactions = transactions.map { PlaidTransaction(transaction: $0) }
                 callBack(response: response.response!, account: PlaidAccount(account: accountData), plaidTransactions: plaidTransactions, error: nil)
+                return
             }
             callBack(response: response.response!, account: nil, plaidTransactions: nil, error: nil)
         }


### PR DESCRIPTION
Hi Nate,

I noticed that the PlaidSwiftClient always calls the callback with nil data when downloadAccountData is called due to an accidental fallthrough when the transaction data is successfully downloaded.  A simple return statement fixes the issue.

Thanks,
Jason Ji
